### PR TITLE
Add comprehensive test coverage for exclusive labels plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/org/jenkinsci/plugins/exclusive/label/ExclusiveLabelVisitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/exclusive/label/ExclusiveLabelVisitorTest.java
@@ -1,0 +1,141 @@
+package org.jenkinsci.plugins.exclusive.label;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.labels.LabelAtom;
+import hudson.model.labels.LabelExpression;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExclusiveLabelVisitorTest {
+
+    private ExclusiveLabelVisitor visitor;
+    private Set<LabelAtom> exclusiveLabels;
+    private LabelAtom label1;
+    private LabelAtom label2;
+    private LabelAtom label3;
+
+    @BeforeEach
+    void setUp() {
+        visitor = new ExclusiveLabelVisitor();
+        exclusiveLabels = new HashSet<>();
+        label1 = new LabelAtom("exclusive1");
+        label2 = new LabelAtom("exclusive2");
+        label3 = new LabelAtom("regular");
+        
+        exclusiveLabels.add(label1);
+        exclusiveLabels.add(label2);
+    }
+
+    @Test
+    void testOnAtom_ExclusiveLabel() {
+        assertTrue(visitor.onAtom(label1, exclusiveLabels));
+        assertTrue(visitor.onAtom(label2, exclusiveLabels));
+    }
+
+    @Test
+    void testOnAtom_NonExclusiveLabel() {
+        assertFalse(visitor.onAtom(label3, exclusiveLabels));
+    }
+
+    @Test
+    void testOnParen() {
+        LabelExpression.Paren paren = new LabelExpression.Paren(label1);
+        assertTrue(visitor.onParen(paren, exclusiveLabels));
+        
+        LabelExpression.Paren parenNonExclusive = new LabelExpression.Paren(label3);
+        assertFalse(visitor.onParen(parenNonExclusive, exclusiveLabels));
+    }
+
+    @Test
+    void testOnNot_WithAtom() {
+        LabelExpression.Not notExclusive = new LabelExpression.Not(label1);
+        assertFalse(visitor.onNot(notExclusive, exclusiveLabels));
+        
+        LabelExpression.Not notRegular = new LabelExpression.Not(label3);
+        assertTrue(visitor.onNot(notRegular, exclusiveLabels));
+    }
+
+    @Test
+    void testOnNot_WithExpression() {
+        LabelExpression.Paren paren = new LabelExpression.Paren(label1);
+        LabelExpression.Not notParen = new LabelExpression.Not(paren);
+        assertFalse(visitor.onNot(notParen, exclusiveLabels));
+    }
+
+    @Test
+    void testOnAnd_BothExclusive() {
+        LabelExpression.And and = new LabelExpression.And(label1, label2);
+        assertTrue(visitor.onAnd(and, exclusiveLabels));
+    }
+
+    @Test
+    void testOnAnd_OneExclusive() {
+        LabelExpression.And and = new LabelExpression.And(label1, label3);
+        assertTrue(visitor.onAnd(and, exclusiveLabels));
+    }
+
+    @Test
+    void testOnAnd_NoneExclusive() {
+        LabelExpression.And and = new LabelExpression.And(label3, new LabelAtom("another"));
+        assertFalse(visitor.onAnd(and, exclusiveLabels));
+    }
+
+    @Test
+    void testOnOr_BothExclusive() {
+        LabelExpression.Or or = new LabelExpression.Or(label1, label2);
+        assertTrue(visitor.onOr(or, exclusiveLabels));
+    }
+
+    @Test
+    void testOnOr_OneExclusive() {
+        LabelExpression.Or or = new LabelExpression.Or(label1, label3);
+        assertTrue(visitor.onOr(or, exclusiveLabels));
+    }
+
+    @Test
+    void testOnOr_NoneExclusive() {
+        LabelExpression.Or or = new LabelExpression.Or(label3, new LabelAtom("another"));
+        assertFalse(visitor.onOr(or, exclusiveLabels));
+    }
+
+    @Test
+    void testOnIff_BothExclusive() {
+        LabelExpression.Iff iff = new LabelExpression.Iff(label1, label2);
+        assertTrue(visitor.onIff(iff, exclusiveLabels));
+    }
+
+    @Test
+    void testOnIff_OneExclusive() {
+        LabelExpression.Iff iff = new LabelExpression.Iff(label1, label3);
+        assertTrue(visitor.onIff(iff, exclusiveLabels));
+    }
+
+    @Test
+    void testOnIff_NoneExclusive() {
+        LabelExpression.Iff iff = new LabelExpression.Iff(label3, new LabelAtom("another"));
+        assertFalse(visitor.onIff(iff, exclusiveLabels));
+    }
+
+    @Test
+    void testOnImplies_ExclusiveConsequent() {
+        LabelExpression.Implies implies = new LabelExpression.Implies(label3, label1);
+        assertTrue(visitor.onImplies(implies, exclusiveLabels));
+    }
+
+    @Test
+    void testOnImplies_NonExclusiveConsequent() {
+        LabelExpression.Implies implies = new LabelExpression.Implies(label1, label3);
+        assertFalse(visitor.onImplies(implies, exclusiveLabels));
+    }
+
+    @Test
+    void testEmptyExclusiveLabels() {
+        Set<LabelAtom> empty = new HashSet<>();
+        assertFalse(visitor.onAtom(label1, empty));
+        assertFalse(visitor.onAtom(label2, empty));
+        assertFalse(visitor.onAtom(label3, empty));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/exclusive/label/ExclusiveLabelsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/exclusive/label/ExclusiveLabelsTest.java
@@ -1,14 +1,39 @@
 package org.jenkinsci.plugins.exclusive.label;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue.BuildableItem;
+import hudson.model.Queue.Task;
+import hudson.model.labels.LabelAtom;
+import hudson.model.queue.CauseOfBlockage;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class ExclusiveLabelsTest {
+
+    private ExclusiveLabels exclusiveLabels;
+    private Node mockNode;
+    private BuildableItem mockItem;
+    private Task mockTask;
+    private Label mockLabel;
+
+    @BeforeEach
+    void setUp(JenkinsRule r) {
+        exclusiveLabels = r.jenkins.getExtensionList(ExclusiveLabels.class).get(0);
+        mockNode = mock(Node.class);
+        mockItem = mock(BuildableItem.class);
+        mockTask = mock(Task.class);
+        mockLabel = mock(Label.class);
+        mockItem.task = mockTask;
+    }
 
     @Test
     void testConfigRoundtrip(JenkinsRule r) throws Exception {
@@ -22,5 +47,111 @@ class ExclusiveLabelsTest {
         assertEquals(2, after.getExclusiveLabels().size());
         assertTrue(after.getExclusiveLabels().stream().anyMatch(l -> l.getName().equals("exclusive1")));
         assertTrue(after.getExclusiveLabels().stream().anyMatch(l -> l.getName().equals("exclusive2")));
+    }
+
+    @Test
+    void testCanTake_NoAssignedLabel_NodeHasExclusiveLabel() {
+        // Setup exclusive labels
+        ((ExclusiveLabels.DescriptorImpl) exclusiveLabels.getDescriptor()).setLabelsInString("exclusive1");
+        
+        // Mock node with exclusive label
+        Set<LabelAtom> nodeLabels = new HashSet<>();
+        nodeLabels.add(new LabelAtom("exclusive1"));
+        when(mockNode.getAssignedLabels()).thenReturn(nodeLabels);
+        
+        // Mock task with no assigned label
+        when(mockTask.getAssignedLabel()).thenReturn(null);
+        
+        CauseOfBlockage result = exclusiveLabels.canTake(mockNode, mockItem);
+        assertNotNull(result);
+        assertInstanceOf(ExclusiveLabels.NotExclusiveLabel.class, result);
+    }
+
+    @Test
+    void testCanTake_AssignedLabelDoesNotContainNode() {
+        // Mock assigned label that doesn't contain the node
+        when(mockTask.getAssignedLabel()).thenReturn(mockLabel);
+        when(mockLabel.contains(mockNode)).thenReturn(false);
+        
+        CauseOfBlockage result = exclusiveLabels.canTake(mockNode, mockItem);
+        assertNull(result);
+    }
+
+    @Test
+    void testCanTake_NodeHasNoExclusiveLabels() {
+        // Setup exclusive labels
+        ((ExclusiveLabels.DescriptorImpl) exclusiveLabels.getDescriptor()).setLabelsInString("exclusive1");
+        
+        // Mock node with no exclusive labels
+        Set<LabelAtom> nodeLabels = new HashSet<>();
+        nodeLabels.add(new LabelAtom("regular"));
+        when(mockNode.getAssignedLabels()).thenReturn(nodeLabels);
+        
+        when(mockTask.getAssignedLabel()).thenReturn(mockLabel);
+        when(mockLabel.contains(mockNode)).thenReturn(true);
+        
+        CauseOfBlockage result = exclusiveLabels.canTake(mockNode, mockItem);
+        assertNull(result);
+    }
+
+    @Test
+    void testCanTake_AssignedLabelDoesNotContainExclusiveLabel() {
+        // Setup exclusive labels
+        ((ExclusiveLabels.DescriptorImpl) exclusiveLabels.getDescriptor()).setLabelsInString("exclusive1");
+        
+        // Mock node with exclusive label
+        Set<LabelAtom> nodeLabels = new HashSet<>();
+        nodeLabels.add(new LabelAtom("exclusive1"));
+        when(mockNode.getAssignedLabels()).thenReturn(nodeLabels);
+        
+        // Mock assigned label that doesn't contain exclusive label
+        when(mockTask.getAssignedLabel()).thenReturn(mockLabel);
+        when(mockLabel.contains(mockNode)).thenReturn(true);
+        when(mockLabel.getName()).thenReturn("regular");
+        
+        CauseOfBlockage result = exclusiveLabels.canTake(mockNode, mockItem);
+        assertNotNull(result);
+        assertInstanceOf(ExclusiveLabels.NotExclusiveLabel.class, result);
+    }
+
+    @Test
+    void testNotExclusiveLabel_ShortDescription() {
+        when(mockNode.getDisplayName()).thenReturn("TestNode");
+        
+        ExclusiveLabels.NotExclusiveLabel blockage = new ExclusiveLabels.NotExclusiveLabel(mockNode);
+        assertEquals("Node TestNode has exclusive label(s)", blockage.getShortDescription());
+    }
+
+    @Test
+    void testDescriptor_EmptyLabelsString() {
+        ExclusiveLabels.DescriptorImpl descriptor = new ExclusiveLabels.DescriptorImpl();
+        descriptor.setLabelsInString("");
+        
+        assertTrue(descriptor.getLabels().isEmpty());
+    }
+
+    @Test
+    void testDescriptor_NullLabelsString() {
+        ExclusiveLabels.DescriptorImpl descriptor = new ExclusiveLabels.DescriptorImpl();
+        descriptor.setLabelsInString(null);
+        
+        assertTrue(descriptor.getLabels().isEmpty());
+    }
+
+    @Test
+    void testDescriptor_MultipleLabels() {
+        ExclusiveLabels.DescriptorImpl descriptor = new ExclusiveLabels.DescriptorImpl();
+        descriptor.setLabelsInString("label1 label2 label3");
+        
+        assertEquals(3, descriptor.getLabels().size());
+        assertTrue(descriptor.getLabels().stream().anyMatch(l -> l.getName().equals("label1")));
+        assertTrue(descriptor.getLabels().stream().anyMatch(l -> l.getName().equals("label2")));
+        assertTrue(descriptor.getLabels().stream().anyMatch(l -> l.getName().equals("label3")));
+    }
+
+    @Test
+    void testDescriptor_DisplayName() {
+        ExclusiveLabels.DescriptorImpl descriptor = new ExclusiveLabels.DescriptorImpl();
+        assertEquals("Exclusive labels", descriptor.getDisplayName());
     }
 }


### PR DESCRIPTION
Fixes #9

## Changes
- Add `ExclusiveLabelVisitorTest` with complete coverage of all label expression types
- Expand `ExclusiveLabelsTest` with queue blocking logic tests and edge cases  
- Add Mockito dependency for proper unit testing

## Test Coverage Added
- Atom labels (exclusive/non-exclusive)
- Parentheses, NOT, AND, OR, IFF, IMPLIES operations
- Queue dispatcher logic for exclusive label enforcement
- Configuration and descriptor functionality
- Edge cases and error conditions

## Verification
All tests pass and provide comprehensive coverage for the plugin's core functionality.